### PR TITLE
frontend: fix logout and clean up html

### DIFF
--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -35,39 +35,26 @@
 </head>
 
 <body style="padding-top: 5rem">
-    <nav class="nav navbar-custom fixed-top">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="navbar-brand" href="/">
-                    <img src="/static/assets/twitter-32.png" width="32" height="32" class="d-inline-block align-top"
-                        alt="">
-                    Twetter
-                </a>
-            </li>
-        </ul>
+    <nav class="nav navbar-custom fixed-top" style="padding: .5rem">
+
+        <a class="navbar-brand mr-auto" href="/">
+            <img src="/static/assets/twitter-32.png" width="32" height="32" class="d-inline-block align-top" alt="">
+            Twetter
+        </a>
 
         {% if g.user %}
-        <ul class="navbar-nav mr-3">
-            <li class="nav-item">
-                <a id="logoutButton" class="nav-link" href="" onclick="onLogout()">Log Out</a>
-            </li>
-        </ul>
+
+        <a class="nav-link mr-3" id="logoutButton" class="nav-link" href="#" onclick="onLogout()">Log Out</a>
+
         <form class="form-inline" id="searchForm" action="/tweets/search_word" method="get" onsubmit="onSearch()">
             <input class="form-control mr-sm-2" id="search" name="search" type="search" placeholder="Search"
                 aria-label="Search" required>
             <button class="btn btn-outline-light my-2 my-sm-0">Search</button>
         </form>
         {% else %}
-        <ul class="navbar-nav mr-3">
-            <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('auth.login') }}">Log In</a>
-            </li>
-        </ul>
-        <ul class="navbar-nav">
-            <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('auth.register') }}">Register</a>
-            </li>
-        </ul>
+        <a class="nav-link mr-3" href="{{ url_for('auth.login') }}">Log In</a>
+
+        <a class="nav-link mr-3" href="{{ url_for('auth.register') }}">Register</a>
         {% endif %}
 
     </nav>

--- a/flaskr/templates/tweets/all_tweets.html
+++ b/flaskr/templates/tweets/all_tweets.html
@@ -8,9 +8,15 @@
 <script>
     function submitTweet() {
         const submit_tweet_action = async () => {
+            document.getElementById('createTweetError').style.display = 'none'
             let form_data = new FormData(document.getElementById('createTweetForm'));
 
             var target_url = "/tweets/new_tweet";
+
+            if (form_data.get('title') == "" || form_data.get('content') == "") {
+                document.getElementById('createTweetError').style.display = 'block'
+                return
+            }
 
             const request = await fetch(target_url, {
                 "method": "POST",
@@ -24,6 +30,7 @@
     }
 
     window.onload = function () {
+        document.getElementById('createTweetError').style.display = 'none'
         document.getElementById('tweet_submit').onclick = function (_) {
             submitTweet()
         }
@@ -40,8 +47,10 @@
             <label for="content">Tell us what you think</label>
             <textarea class="form-control" id="content" name="content" rows="4" required></textarea>
         </div>
+        <p id="createTweetError" class="text-danger">
+            Oops! Missing a required field
+        </p>
         <small id="under_text" class="form-text text-muted">Always happy to see you.</small>
-
         <div class="text-right">
             <button type="button" class="btn btn-primary" id="tweet_submit">Submit Tweet</button>
         </div>
@@ -50,7 +59,7 @@
 
 
 <div>
-    <ul class="list-group ">
+    <ul class="list-group">
         {% for tweet, author in tweets_authors: %}
         <li class="list-group-item" id="{{tweet.id}}">
             <div class="flex-column">


### PR DESCRIPTION
An issue on firefox was causing the logout post to fail because we were missing the `#` in the href 

Also cleaning up some HTML as we do not need all the `ul` and `li`

and adding basic validation for the create tweet call